### PR TITLE
[HOTFIX] Last Game Category

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,14 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: deepakputhraya/action-branch-name@master
-        with:
-          regex: '([a-z])+\/([a-z0-9\-@_])+' # Regex the branch should match. This example enforces grouping
-          allowed_prefixes: 'release' # All branches should start with the given prefix
-          ignore: master,develop # Ignore exactly matching branch names from convention
-          min_length: 5 # Min length of the branch name
-          max_length: 50 # Max length of the branch name
-
       - uses: hmarr/auto-approve-action@v2.0.0
+        if: ${{ startsWith(github.head_ref, "release/") || startsWith(github.head_ref, "backport/") }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v2.0.0
-        if: ${{ github.base_ref == "master" && (startsWith(github.head_ref, "release/") || startsWith(github.head_ref, "backport/")) }}
+        if: ${{ github.base_ref == "master" && startsWith(github.head_ref, "release/") || github.base_ref == "develop" && startsWith(github.head_ref, "backport/") }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v2.0.0
-        if: ${{ startsWith(github.head_ref, "release/") || startsWith(github.head_ref, "backport/") }}
+        if: ${{ github.base_ref == "master" && (startsWith(github.head_ref, "release/") || startsWith(github.head_ref, "backport/")) }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/src/main/kotlin/com/coder_rangers/mobius_api/dao/implementations/GameDAO.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/dao/implementations/GameDAO.kt
@@ -12,13 +12,13 @@ class GameDAO @Autowired constructor(
     private val gameRepository: IGameRepository
 ) : IGameDAO {
     override fun getMaxIdByCategory(category: Game.Category): Long =
-        gameRepository.getMaxIdByCategory(category)
+        gameRepository.getMaxTestIdByCategory(category)
 
     override fun getMinIdByCategory(category: Game.Category): Long =
-        gameRepository.getMinIdByCategory(category)
+        gameRepository.getMinTestIdByCategory(category)
 
-    override fun findGameById(id: Long): Game? = gameRepository.findByIdOrNull(id)
+    override fun getGameById(id: Long): Game? = gameRepository.findByIdOrNull(id)
 
-    override fun findGameByCategory(category: Game.Category): Game =
-        gameRepository.getGameByCategory(category)
+    override fun getGameByCategory(category: Game.Category): Game =
+        gameRepository.getFirstByCategory(category)
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/dao/implementations/GameDAO.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/dao/implementations/GameDAO.kt
@@ -18,7 +18,4 @@ class GameDAO @Autowired constructor(
         gameRepository.getMinTestIdByCategory(category)
 
     override fun getGameById(id: Long): Game? = gameRepository.findByIdOrNull(id)
-
-    override fun getGameByCategory(category: Game.Category): Game =
-        gameRepository.getFirstByCategory(category)
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/dao/interfaces/IGameDAO.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/dao/interfaces/IGameDAO.kt
@@ -7,5 +7,4 @@ interface IGameDAO {
     fun getMaxIdByCategory(category: Category): Long
     fun getMinIdByCategory(category: Category): Long
     fun getGameById(id: Long): Game?
-    fun getGameByCategory(category: Category): Game
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/dao/interfaces/IGameDAO.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/dao/interfaces/IGameDAO.kt
@@ -6,6 +6,6 @@ import com.coder_rangers.mobius_api.models.Game.Category
 interface IGameDAO {
     fun getMaxIdByCategory(category: Category): Long
     fun getMinIdByCategory(category: Category): Long
-    fun findGameById(id: Long): Game?
-    fun findGameByCategory(category: Category): Game
+    fun getGameById(id: Long): Game?
+    fun getGameByCategory(category: Category): Game
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/database/repositories/IGameRepository.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/database/repositories/IGameRepository.kt
@@ -12,13 +12,11 @@ import org.springframework.transaction.annotation.Transactional
 @Repository
 @Transactional
 interface IGameRepository : JpaRepository<Game, Long>, JpaSpecificationExecutor<Game> {
-    @Query("SELECT MAX(g.id) FROM Game g WHERE g.category = ?1 AND g.isTest = true")
+    @Query("SELECT MAX(g.id) FROM Game g WHERE g.category = ?1 AND g.isTestGame = true")
     @RestResource(exported = false)
     fun getMaxTestIdByCategory(category: Category): Long
 
-    @Query("SELECT MIN(g.id) FROM Game g WHERE g.category = ?1 AND g.isTest = true")
+    @Query("SELECT MIN(g.id) FROM Game g WHERE g.category = ?1 AND g.isTestGame = true")
     @RestResource(exported = false)
     fun getMinTestIdByCategory(category: Category): Long
-
-    fun getFirstByCategory(category: Category): Game
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/database/repositories/IGameRepository.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/database/repositories/IGameRepository.kt
@@ -12,13 +12,13 @@ import org.springframework.transaction.annotation.Transactional
 @Repository
 @Transactional
 interface IGameRepository : JpaRepository<Game, Long>, JpaSpecificationExecutor<Game> {
-    @Query("SELECT MAX(g.id) FROM Game g WHERE g.category = ?1")
+    @Query("SELECT MAX(g.id) FROM Game g WHERE g.category = ?1 AND g.isTest = true")
     @RestResource(exported = false)
-    fun getMaxIdByCategory(category: Category): Long
+    fun getMaxTestIdByCategory(category: Category): Long
 
-    @Query("SELECT MIN(g.id) FROM Game g WHERE g.category = ?1")
+    @Query("SELECT MIN(g.id) FROM Game g WHERE g.category = ?1 AND g.isTest = true")
     @RestResource(exported = false)
-    fun getMinIdByCategory(category: Category): Long
+    fun getMinTestIdByCategory(category: Category): Long
 
-    fun getGameByCategory(category: Category): Game
+    fun getFirstByCategory(category: Category): Game
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/models/Game.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/models/Game.kt
@@ -39,7 +39,7 @@ class Game(
     @field:NotEmpty
     val tasks: List<Task>,
 
-    val isTest: Boolean = false,
+    val isTestGame: Boolean = false,
 
     @OneToMany(mappedBy = "game", cascade = [ALL])
     val resources: List<Resource>? = null

--- a/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/GameService.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/GameService.kt
@@ -23,7 +23,7 @@ class GameService @Autowired constructor(
         return getGameById(randomId)
     }
 
-    override fun getSpecificGameByCategory(category: Category): Game = gameDAO.findGameByCategory(category)
+    override fun getSpecificGameByCategory(category: Category): Game = gameDAO.getGameByCategory(category)
 
-    override fun getGameById(id: Long): Game = gameDAO.findGameById(id) ?: throw GameNotFoundException(id)
+    override fun getGameById(id: Long): Game = gameDAO.getGameById(id) ?: throw GameNotFoundException(id)
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/GameService.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/GameService.kt
@@ -23,7 +23,5 @@ class GameService @Autowired constructor(
         return getGameById(randomId)
     }
 
-    override fun getSpecificGameByCategory(category: Category): Game = gameDAO.getGameByCategory(category)
-
     override fun getGameById(id: Long): Game = gameDAO.getGameById(id) ?: throw GameNotFoundException(id)
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/MentalTestService.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/MentalTestService.kt
@@ -9,13 +9,9 @@ import com.coder_rangers.mobius_api.models.Game.Category
 import com.coder_rangers.mobius_api.models.Game.Category.ATTENTION
 import com.coder_rangers.mobius_api.models.Game.Category.CALCULATION
 import com.coder_rangers.mobius_api.models.Game.Category.COMPREHENSION
-import com.coder_rangers.mobius_api.models.Game.Category.FIXATION
 import com.coder_rangers.mobius_api.models.Game.Category.MEMORY
 import com.coder_rangers.mobius_api.models.Game.Category.ORIENTATION
 import com.coder_rangers.mobius_api.models.Game.Category.READING
-import com.coder_rangers.mobius_api.models.Game.Category.REPETITION
-import com.coder_rangers.mobius_api.models.Game.Category.VISUALIZATION
-import com.coder_rangers.mobius_api.models.Game.Category.WRITING
 import com.coder_rangers.mobius_api.models.Patient
 import com.coder_rangers.mobius_api.requests.categories.AttentionTestGameAnswersRequest
 import com.coder_rangers.mobius_api.requests.categories.NumericTestGameAnswersRequest
@@ -49,20 +45,6 @@ class MentalTestService @Autowired constructor(
     @Qualifier("comprehensionGameAnswersResolver")
     private val comprehensionGameAnswersResolver: IGameAnswersResolver<String>
 ) : IMentalTestService {
-    private companion object {
-        private val RANDOM_GAME_CATEGORIES = setOf(
-            FIXATION,
-            ATTENTION,
-            CALCULATION,
-            ATTENTION,
-            VISUALIZATION,
-            COMPREHENSION,
-            WRITING,
-            REPETITION,
-            READING
-        )
-    }
-
     override fun getMentalTestGame(patient: Patient, nextCategoryType: Category): Game {
         if (patient.testStatus == FINISHED) {
             throw FinishedTestException(patient.id)
@@ -103,14 +85,6 @@ class MentalTestService @Autowired constructor(
         }
     }
 
-    private fun getSpecificOrRandomGame(nextGameCategory: Category): Game {
-        return if (isRandomGameCategory(nextGameCategory)) {
-            gameService.getRandomGameByCategory(nextGameCategory)
-        } else {
-            gameService.getSpecificGameByCategory(nextGameCategory)
-        }
-    }
-
-    private fun isRandomGameCategory(nextGameCategory: Category) =
-        nextGameCategory in RANDOM_GAME_CATEGORIES
+    private fun getSpecificOrRandomGame(nextGameCategory: Category): Game =
+        gameService.getRandomGameByCategory(nextGameCategory)
 }

--- a/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/PatientService.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/PatientService.kt
@@ -5,7 +5,7 @@ import com.coder_rangers.mobius_api.enums.TestStatus.FINISHED
 import com.coder_rangers.mobius_api.error.exceptions.PatientNotFoundException
 import com.coder_rangers.mobius_api.models.Game
 import com.coder_rangers.mobius_api.models.Game.Category
-import com.coder_rangers.mobius_api.models.Game.Category.VISUALIZATION
+import com.coder_rangers.mobius_api.models.Game.Category.READING
 import com.coder_rangers.mobius_api.models.Patient
 import com.coder_rangers.mobius_api.requests.categories.TestGameAnswersRequest
 import com.coder_rangers.mobius_api.services.interfaces.IMentalTestService
@@ -38,7 +38,7 @@ class PatientService @Autowired constructor(
         patientDAO.findActivePatientById(id) ?: throw PatientNotFoundException(id)
 
     // TODO: update last category
-    private fun isLastTestCategory(category: Category) = category == VISUALIZATION
+    private fun isLastTestCategory(category: Category) = category == READING
 
     private fun updateTestStatus(patient: Patient, category: Category) {
         if (isLastTestCategory(category)) {

--- a/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/PatientService.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/PatientService.kt
@@ -5,7 +5,7 @@ import com.coder_rangers.mobius_api.enums.TestStatus.FINISHED
 import com.coder_rangers.mobius_api.error.exceptions.PatientNotFoundException
 import com.coder_rangers.mobius_api.models.Game
 import com.coder_rangers.mobius_api.models.Game.Category
-import com.coder_rangers.mobius_api.models.Game.Category.READING
+import com.coder_rangers.mobius_api.models.Game.Category.WRITING
 import com.coder_rangers.mobius_api.models.Patient
 import com.coder_rangers.mobius_api.requests.categories.TestGameAnswersRequest
 import com.coder_rangers.mobius_api.services.interfaces.IMentalTestService
@@ -38,7 +38,7 @@ class PatientService @Autowired constructor(
         patientDAO.findActivePatientById(id) ?: throw PatientNotFoundException(id)
 
     // TODO: update last category
-    private fun isLastTestCategory(category: Category) = category == READING
+    private fun isLastTestCategory(category: Category) = category == WRITING
 
     private fun updateTestStatus(patient: Patient, category: Category) {
         if (isLastTestCategory(category)) {

--- a/src/main/kotlin/com/coder_rangers/mobius_api/services/interfaces/IGameService.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/services/interfaces/IGameService.kt
@@ -4,7 +4,6 @@ import com.coder_rangers.mobius_api.models.Game
 import com.coder_rangers.mobius_api.models.Game.Category
 
 interface IGameService {
-    fun getRandomGameByCategory(category: Game.Category): Game
-    fun getSpecificGameByCategory(category: Game.Category): Game
+    fun getRandomGameByCategory(category: Category): Game
     fun getGameById(id: Long): Game
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -43,7 +43,7 @@ VALUES (6, 1);
 INSERT INTO public.patient_guardian (patient_id, guardian_id)
 VALUES (7, 1);
 
-INSERT INTO public.games (category, name, description, is_test)
+INSERT INTO public.games (category, name, description, is_test_game)
 VALUES ('ORIENTATION', 'Juego de orientación', 'Responda las siguientes preguntas', true),
        ('FIXATION', 'Juego de fijación', null, true),
        ('CALCULATION', 'Juego de cálculo', null, true),

--- a/src/test/kotlin/com/coder_rangers/mobius_api/unit/services/GameServiceTest.kt
+++ b/src/test/kotlin/com/coder_rangers/mobius_api/unit/services/GameServiceTest.kt
@@ -27,7 +27,7 @@ class GameServiceTest {
         // GIVEN
         every { gameDAO.getMaxIdByCategory(any()) } returns 2L
         every { gameDAO.getMinIdByCategory(any()) } returns 1L
-        every { gameDAO.findGameById(any()) } returns null
+        every { gameDAO.getGameById(any()) } returns null
 
         // THEN
         assertThat {

--- a/src/test/kotlin/com/coder_rangers/mobius_api/unit/services/PatientServiceTest.kt
+++ b/src/test/kotlin/com/coder_rangers/mobius_api/unit/services/PatientServiceTest.kt
@@ -1,7 +1,7 @@
 package com.coder_rangers.mobius_api.unit.services
 
 import com.coder_rangers.mobius_api.dao.interfaces.IPatientDAO
-import com.coder_rangers.mobius_api.models.Game.Category.READING
+import com.coder_rangers.mobius_api.models.Game.Category.WRITING
 import com.coder_rangers.mobius_api.models.Patient
 import com.coder_rangers.mobius_api.requests.categories.TestGameAnswersRequest
 import com.coder_rangers.mobius_api.services.implementations.PatientService
@@ -32,7 +32,7 @@ class PatientServiceTest {
         // GIVEN
         val patient = mockk<Patient>(relaxed = true)
         val testGameAnswersRequest = mockk<TestGameAnswersRequest<*>>(relaxed = true) {
-            every { category } returns READING // TODO: update last category
+            every { category } returns WRITING // TODO: update last category
         }
         every { patientDAO.findActivePatientById(any()) } returns patient
 

--- a/src/test/kotlin/com/coder_rangers/mobius_api/unit/services/PatientServiceTest.kt
+++ b/src/test/kotlin/com/coder_rangers/mobius_api/unit/services/PatientServiceTest.kt
@@ -1,7 +1,7 @@
 package com.coder_rangers.mobius_api.unit.services
 
 import com.coder_rangers.mobius_api.dao.interfaces.IPatientDAO
-import com.coder_rangers.mobius_api.models.Game.Category.VISUALIZATION
+import com.coder_rangers.mobius_api.models.Game.Category.READING
 import com.coder_rangers.mobius_api.models.Patient
 import com.coder_rangers.mobius_api.requests.categories.TestGameAnswersRequest
 import com.coder_rangers.mobius_api.services.implementations.PatientService
@@ -32,7 +32,7 @@ class PatientServiceTest {
         // GIVEN
         val patient = mockk<Patient>(relaxed = true)
         val testGameAnswersRequest = mockk<TestGameAnswersRequest<*>>(relaxed = true) {
-            every { category } returns VISUALIZATION // TODO: update last category
+            every { category } returns READING // TODO: update last category
         }
         every { patientDAO.findActivePatientById(any()) } returns patient
 


### PR DESCRIPTION
## Motivación y contexto
<!---
¿Por qué hay que hacer este cambio?
¿Qué problema resuelve?
¿Qué nueva funcionalidad implementa?
-->

Se encontró un bug en el que, una vez llegado a visualización, no se podía avanzar más en los juegos mentales. Esto se debía a que no se actualizó la última categoría jugable en el código.
Además, se agregó un control para que, en los juegos random, solo se traigan ids máximos y mínimos de aquellos juegos que solo son de test.

## ¿Cómo fue probado?
<!--- Poné una x en las cajas que apliquen: -->
- [x] Entorno local
- [x] Stage

<!--- Describí, si es necesario, cómo probaste este cambio. -->
<!--- Sigue estando disponible en stage? Incluí cualquier otro detalle relevante a la 
forma de testear el cambio. -->
