### PR TITLE
[HOTFIX] Guardian and Patient Relationship

### DIFF
--- a/src/main/kotlin/com/coder_rangers/mobius_api/models/Guardian.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/models/Guardian.kt
@@ -39,9 +39,10 @@ class Guardian(
         inverseJoinColumns = [
             JoinColumn(
                 name = "patient_id",
-                referencedColumnName = "id"
+                referencedColumnName = "id",
+                nullable = false
             )
         ]
     )
-    val patients: Set<Patient>? = null
+    val patients: MutableSet<Patient> = mutableSetOf()
 )

--- a/src/main/kotlin/com/coder_rangers/mobius_api/models/Patient.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/models/Patient.kt
@@ -61,7 +61,7 @@ class Patient(
     val birthday: LocalDate,
 
     @ManyToMany(mappedBy = "patients", cascade = [ALL])
-    val guardians: Set<Guardian>,
+    val guardians: MutableSet<Guardian> = mutableSetOf(),
 
     @Enumerated(STRING)
     @Column(nullable = false, updatable = false)

--- a/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/SecurityService.kt
+++ b/src/main/kotlin/com/coder_rangers/mobius_api/services/implementations/SecurityService.kt
@@ -23,19 +23,21 @@ class SecurityService @Autowired constructor(
         val guardianEmail = signUpRequest.guardianEmail
 
         assertGuardianIsNotAPatient(guardianEmail)
-        patientService.createOrUpdatePatient(
-            Patient(
-                firstName = signUpRequest.firstName,
-                lastName = signUpRequest.lastName,
-                email = signUpRequest.patientEmail,
-                birthday = signUpRequest.birthday,
-                password = signUpRequest.password.fromBase64ToSHA256(),
-                guardians = setOf(
-                    guardianService.getOrCreateGuardian(guardianEmail)
-                ),
-                genre = signUpRequest.genre
-            )
-        )
+
+        val guardian = guardianService.getOrCreateGuardian(guardianEmail)
+
+        Patient(
+            firstName = signUpRequest.firstName,
+            lastName = signUpRequest.lastName,
+            email = signUpRequest.patientEmail,
+            birthday = signUpRequest.birthday,
+            password = signUpRequest.password.fromBase64ToSHA256(),
+            genre = signUpRequest.genre
+        ).let { patient ->
+            patient.guardians.add(guardian)
+            guardian.patients.add(patient)
+            patientService.createOrUpdatePatient(patient)
+        }
     }
 
     private fun assertGuardianIsNotAPatient(guardianEmail: String) {


### PR DESCRIPTION
## Motivación y contexto
<!---
¿Por qué hay que hacer este cambio?
¿Qué problema resuelve?
¿Qué nueva funcionalidad implementa?
-->

Se encontró un bug en el cual, cuando un usuario se registraba con un nuevo guardián, este se creaba, pero no se relacionaba el paciente con el guardián nuevo. Este hotfix soluciona este problema.

## ¿Cómo fue probado?
<!--- Poné una x en las cajas que apliquen: -->
- [x] Entorno local
- [x] Stage

<!--- Describí, si es necesario, cómo probaste este cambio. -->
<!--- Sigue estando disponible en stage? Incluí cualquier otro detalle relevante a la 
forma de testear el cambio. -->
